### PR TITLE
PS-2141 - ID Standardization

### DIFF
--- a/java/src/main/java/com/pti/sdk/resources/marketplace/MarketplaceClient.java
+++ b/java/src/main/java/com/pti/sdk/resources/marketplace/MarketplaceClient.java
@@ -81,6 +81,9 @@ public class MarketplaceClient {
       properties.put("feeRecipients", request.getFeeRecipients());
     }
     properties.put("type", request.getType());
+    if (request.getId().isPresent()) {
+      properties.put("id", request.getId());
+    }
     if (request.getTransactionGroupId().isPresent()) {
       properties.put("transactionGroupId", request.getTransactionGroupId());
     }
@@ -187,6 +190,9 @@ public class MarketplaceClient {
       properties.put("feeRecipients", request.getFeeRecipients());
     }
     properties.put("type", request.getType());
+    if (request.getId().isPresent()) {
+      properties.put("id", request.getId());
+    }
     if (request.getTransactionGroupId().isPresent()) {
       properties.put("transactionGroupId", request.getTransactionGroupId());
     }

--- a/java/src/main/java/com/pti/sdk/resources/marketplace/requests/ExecuteBuyTransaction.java
+++ b/java/src/main/java/com/pti/sdk/resources/marketplace/requests/ExecuteBuyTransaction.java
@@ -39,6 +39,8 @@ import org.jetbrains.annotations.NotNull;
 public final class ExecuteBuyTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -79,16 +81,18 @@ public final class ExecuteBuyTransaction implements ITransactionType, ITransacti
 
   private final Map<String, Object> additionalProperties;
 
-  private ExecuteBuyTransaction(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
-      String ptiRequestId, String ptiScenarioId, Optional<String> ptiSessionId,
-      Optional<Boolean> ptiDisableWebhook, Optional<String> ptiProviderName,
-      Optional<DigitalItem> digitalItem, Optional<List<DigitalItem>> digitalItems,
-      OneOfPaymentMethod sourceMethod, Optional<OneOfUserSubTypes> seller,
-      Optional<List<FeeRecipient>> feeRecipients, Map<String, Object> additionalProperties) {
+  private ExecuteBuyTransaction(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta, String ptiRequestId, String ptiScenarioId,
+      Optional<String> ptiSessionId, Optional<Boolean> ptiDisableWebhook,
+      Optional<String> ptiProviderName, Optional<DigitalItem> digitalItem,
+      Optional<List<DigitalItem>> digitalItems, OneOfPaymentMethod sourceMethod,
+      Optional<OneOfUserSubTypes> seller, Optional<List<FeeRecipient>> feeRecipients,
+      Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -115,6 +119,15 @@ public final class ExecuteBuyTransaction implements ITransactionType, ITransacti
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -260,12 +273,12 @@ public final class ExecuteBuyTransaction implements ITransactionType, ITransacti
   }
 
   private boolean equalTo(ExecuteBuyTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && digitalItem.equals(other.digitalItem) && digitalItems.equals(other.digitalItems) && sourceMethod.equals(other.sourceMethod) && seller.equals(other.seller) && feeRecipients.equals(other.feeRecipients);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && digitalItem.equals(other.digitalItem) && digitalItems.equals(other.digitalItems) && sourceMethod.equals(other.sourceMethod) && seller.equals(other.seller) && feeRecipients.equals(other.feeRecipients);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.digitalItem, this.digitalItems, this.sourceMethod, this.seller, this.feeRecipients);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.digitalItem, this.digitalItems, this.sourceMethod, this.seller, this.feeRecipients);
   }
 
   @Override
@@ -309,6 +322,10 @@ public final class ExecuteBuyTransaction implements ITransactionType, ITransacti
 
   public interface _FinalStage {
     ExecuteBuyTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -407,6 +424,8 @@ public final class ExecuteBuyTransaction implements ITransactionType, ITransacti
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -416,6 +435,7 @@ public final class ExecuteBuyTransaction implements ITransactionType, ITransacti
     @Override
     public Builder from(ExecuteBuyTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -731,9 +751,29 @@ public final class ExecuteBuyTransaction implements ITransactionType, ITransacti
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public ExecuteBuyTransaction build() {
-      return new ExecuteBuyTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, digitalItem, digitalItems, sourceMethod, seller, feeRecipients, additionalProperties);
+      return new ExecuteBuyTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, digitalItem, digitalItems, sourceMethod, seller, feeRecipients, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/resources/marketplace/requests/ExecuteSellTransaction.java
+++ b/java/src/main/java/com/pti/sdk/resources/marketplace/requests/ExecuteSellTransaction.java
@@ -39,6 +39,8 @@ import org.jetbrains.annotations.NotNull;
 public final class ExecuteSellTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -79,16 +81,18 @@ public final class ExecuteSellTransaction implements ITransactionType, ITransact
 
   private final Map<String, Object> additionalProperties;
 
-  private ExecuteSellTransaction(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
-      String ptiRequestId, String ptiScenarioId, Optional<String> ptiSessionId,
-      Optional<Boolean> ptiDisableWebhook, Optional<String> ptiProviderName,
-      Optional<DigitalItem> digitalItem, Optional<List<DigitalItem>> digitalItems,
-      OneOfPaymentMethod destinationMethod, Optional<OneOfUserSubTypes> buyer,
-      Optional<List<FeeRecipient>> feeRecipients, Map<String, Object> additionalProperties) {
+  private ExecuteSellTransaction(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta, String ptiRequestId, String ptiScenarioId,
+      Optional<String> ptiSessionId, Optional<Boolean> ptiDisableWebhook,
+      Optional<String> ptiProviderName, Optional<DigitalItem> digitalItem,
+      Optional<List<DigitalItem>> digitalItems, OneOfPaymentMethod destinationMethod,
+      Optional<OneOfUserSubTypes> buyer, Optional<List<FeeRecipient>> feeRecipients,
+      Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -115,6 +119,15 @@ public final class ExecuteSellTransaction implements ITransactionType, ITransact
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -260,12 +273,12 @@ public final class ExecuteSellTransaction implements ITransactionType, ITransact
   }
 
   private boolean equalTo(ExecuteSellTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && digitalItem.equals(other.digitalItem) && digitalItems.equals(other.digitalItems) && destinationMethod.equals(other.destinationMethod) && buyer.equals(other.buyer) && feeRecipients.equals(other.feeRecipients);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && digitalItem.equals(other.digitalItem) && digitalItems.equals(other.digitalItems) && destinationMethod.equals(other.destinationMethod) && buyer.equals(other.buyer) && feeRecipients.equals(other.feeRecipients);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.digitalItem, this.digitalItems, this.destinationMethod, this.buyer, this.feeRecipients);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.digitalItem, this.digitalItems, this.destinationMethod, this.buyer, this.feeRecipients);
   }
 
   @Override
@@ -309,6 +322,10 @@ public final class ExecuteSellTransaction implements ITransactionType, ITransact
 
   public interface _FinalStage {
     ExecuteSellTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -407,6 +424,8 @@ public final class ExecuteSellTransaction implements ITransactionType, ITransact
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -416,6 +435,7 @@ public final class ExecuteSellTransaction implements ITransactionType, ITransact
     @Override
     public Builder from(ExecuteSellTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -731,9 +751,29 @@ public final class ExecuteSellTransaction implements ITransactionType, ITransact
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public ExecuteSellTransaction build() {
-      return new ExecuteSellTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, digitalItem, digitalItems, destinationMethod, buyer, feeRecipients, additionalProperties);
+      return new ExecuteSellTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, digitalItem, digitalItems, destinationMethod, buyer, feeRecipients, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/resources/transactions/TransactionsClient.java
+++ b/java/src/main/java/com/pti/sdk/resources/transactions/TransactionsClient.java
@@ -127,6 +127,9 @@ public class TransactionsClient {
       properties.put("destinationMethod", request.getDestinationMethod());
     }
     properties.put("type", request.getType());
+    if (request.getId().isPresent()) {
+      properties.put("id", request.getId());
+    }
     if (request.getTransactionGroupId().isPresent()) {
       properties.put("transactionGroupId", request.getTransactionGroupId());
     }
@@ -224,6 +227,9 @@ public class TransactionsClient {
       properties.put("sourceMethod", request.getSourceMethod());
     }
     properties.put("type", request.getType());
+    if (request.getId().isPresent()) {
+      properties.put("id", request.getId());
+    }
     if (request.getTransactionGroupId().isPresent()) {
       properties.put("transactionGroupId", request.getTransactionGroupId());
     }
@@ -320,6 +326,9 @@ public class TransactionsClient {
       properties.put("destinationMethod", request.getDestinationMethod());
     }
     properties.put("type", request.getType());
+    if (request.getId().isPresent()) {
+      properties.put("id", request.getId());
+    }
     if (request.getTransactionGroupId().isPresent()) {
       properties.put("transactionGroupId", request.getTransactionGroupId());
     }
@@ -419,6 +428,9 @@ public class TransactionsClient {
       properties.put("destinationClientId", request.getDestinationClientId());
     }
     properties.put("type", request.getType());
+    if (request.getId().isPresent()) {
+      properties.put("id", request.getId());
+    }
     if (request.getTransactionGroupId().isPresent()) {
       properties.put("transactionGroupId", request.getTransactionGroupId());
     }
@@ -513,6 +525,9 @@ public class TransactionsClient {
     properties.put("sourceMethod", request.getSourceMethod());
     properties.put("destinationMethod", request.getDestinationMethod());
     properties.put("type", request.getType());
+    if (request.getId().isPresent()) {
+      properties.put("id", request.getId());
+    }
     if (request.getTransactionGroupId().isPresent()) {
       properties.put("transactionGroupId", request.getTransactionGroupId());
     }
@@ -607,6 +622,9 @@ public class TransactionsClient {
     properties.put("destination", request.getDestination());
     properties.put("destinationMethod", request.getDestinationMethod());
     properties.put("type", request.getType());
+    if (request.getId().isPresent()) {
+      properties.put("id", request.getId());
+    }
     if (request.getTransactionGroupId().isPresent()) {
       properties.put("transactionGroupId", request.getTransactionGroupId());
     }

--- a/java/src/main/java/com/pti/sdk/resources/transactions/requests/ExecuteDepositTransaction.java
+++ b/java/src/main/java/com/pti/sdk/resources/transactions/requests/ExecuteDepositTransaction.java
@@ -37,6 +37,8 @@ import org.jetbrains.annotations.NotNull;
 public final class ExecuteDepositTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -71,15 +73,16 @@ public final class ExecuteDepositTransaction implements ITransactionType, ITrans
 
   private final Map<String, Object> additionalProperties;
 
-  private ExecuteDepositTransaction(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
-      String ptiRequestId, String ptiScenarioId, Optional<String> ptiSessionId,
-      Optional<Boolean> ptiDisableWebhook, Optional<String> ptiProviderName,
-      OneOfExternalPaymentMethod sourceMethod, Optional<WalletPaymentMethod> destinationMethod,
-      Map<String, Object> additionalProperties) {
+  private ExecuteDepositTransaction(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta, String ptiRequestId, String ptiScenarioId,
+      Optional<String> ptiSessionId, Optional<Boolean> ptiDisableWebhook,
+      Optional<String> ptiProviderName, OneOfExternalPaymentMethod sourceMethod,
+      Optional<WalletPaymentMethod> destinationMethod, Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -103,6 +106,15 @@ public final class ExecuteDepositTransaction implements ITransactionType, ITrans
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -230,12 +242,12 @@ public final class ExecuteDepositTransaction implements ITransactionType, ITrans
   }
 
   private boolean equalTo(ExecuteDepositTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && sourceMethod.equals(other.sourceMethod) && destinationMethod.equals(other.destinationMethod);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && sourceMethod.equals(other.sourceMethod) && destinationMethod.equals(other.destinationMethod);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.sourceMethod, this.destinationMethod);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.sourceMethod, this.destinationMethod);
   }
 
   @Override
@@ -279,6 +291,10 @@ public final class ExecuteDepositTransaction implements ITransactionType, ITrans
 
   public interface _FinalStage {
     ExecuteDepositTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -359,6 +375,8 @@ public final class ExecuteDepositTransaction implements ITransactionType, ITrans
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -368,6 +386,7 @@ public final class ExecuteDepositTransaction implements ITransactionType, ITrans
     @Override
     public Builder from(ExecuteDepositTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -628,9 +647,29 @@ public final class ExecuteDepositTransaction implements ITransactionType, ITrans
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public ExecuteDepositTransaction build() {
-      return new ExecuteDepositTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, sourceMethod, destinationMethod, additionalProperties);
+      return new ExecuteDepositTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, sourceMethod, destinationMethod, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/resources/transactions/requests/ExecuteMintTransaction.java
+++ b/java/src/main/java/com/pti/sdk/resources/transactions/requests/ExecuteMintTransaction.java
@@ -36,6 +36,8 @@ import org.jetbrains.annotations.NotNull;
 public final class ExecuteMintTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -70,15 +72,16 @@ public final class ExecuteMintTransaction implements ITransactionType, ITransact
 
   private final Map<String, Object> additionalProperties;
 
-  private ExecuteMintTransaction(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
-      String ptiRequestId, String ptiScenarioId, Optional<String> ptiSessionId,
-      Optional<Boolean> ptiDisableWebhook, Optional<String> ptiProviderName,
-      OneOfUserSubTypes destination, WalletPaymentMethod destinationMethod,
-      Map<String, Object> additionalProperties) {
+  private ExecuteMintTransaction(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta, String ptiRequestId, String ptiScenarioId,
+      Optional<String> ptiSessionId, Optional<Boolean> ptiDisableWebhook,
+      Optional<String> ptiProviderName, OneOfUserSubTypes destination,
+      WalletPaymentMethod destinationMethod, Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -102,6 +105,15 @@ public final class ExecuteMintTransaction implements ITransactionType, ITransact
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -229,12 +241,12 @@ public final class ExecuteMintTransaction implements ITransactionType, ITransact
   }
 
   private boolean equalTo(ExecuteMintTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && destination.equals(other.destination) && destinationMethod.equals(other.destinationMethod);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && destination.equals(other.destination) && destinationMethod.equals(other.destinationMethod);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.destination, this.destinationMethod);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.destination, this.destinationMethod);
   }
 
   @Override
@@ -282,6 +294,10 @@ public final class ExecuteMintTransaction implements ITransactionType, ITransact
 
   public interface _FinalStage {
     ExecuteMintTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -358,6 +374,8 @@ public final class ExecuteMintTransaction implements ITransactionType, ITransact
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -367,6 +385,7 @@ public final class ExecuteMintTransaction implements ITransactionType, ITransact
     @Override
     public Builder from(ExecuteMintTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -618,9 +637,29 @@ public final class ExecuteMintTransaction implements ITransactionType, ITransact
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public ExecuteMintTransaction build() {
-      return new ExecuteMintTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, destination, destinationMethod, additionalProperties);
+      return new ExecuteMintTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, destination, destinationMethod, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/resources/transactions/requests/ExecutePaymentTransaction.java
+++ b/java/src/main/java/com/pti/sdk/resources/transactions/requests/ExecutePaymentTransaction.java
@@ -37,6 +37,8 @@ import org.jetbrains.annotations.NotNull;
 public final class ExecutePaymentTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -71,15 +73,16 @@ public final class ExecutePaymentTransaction implements ITransactionType, ITrans
 
   private final Map<String, Object> additionalProperties;
 
-  private ExecutePaymentTransaction(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
-      String ptiRequestId, String ptiScenarioId, Optional<String> ptiSessionId,
-      Optional<Boolean> ptiDisableWebhook, Optional<String> ptiProviderName,
-      OneOfPaymentMethod sourceMethod, Optional<WalletPaymentMethod> destinationMethod,
-      Map<String, Object> additionalProperties) {
+  private ExecutePaymentTransaction(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta, String ptiRequestId, String ptiScenarioId,
+      Optional<String> ptiSessionId, Optional<Boolean> ptiDisableWebhook,
+      Optional<String> ptiProviderName, OneOfPaymentMethod sourceMethod,
+      Optional<WalletPaymentMethod> destinationMethod, Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -103,6 +106,15 @@ public final class ExecutePaymentTransaction implements ITransactionType, ITrans
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -230,12 +242,12 @@ public final class ExecutePaymentTransaction implements ITransactionType, ITrans
   }
 
   private boolean equalTo(ExecutePaymentTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && sourceMethod.equals(other.sourceMethod) && destinationMethod.equals(other.destinationMethod);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && sourceMethod.equals(other.sourceMethod) && destinationMethod.equals(other.destinationMethod);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.sourceMethod, this.destinationMethod);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.sourceMethod, this.destinationMethod);
   }
 
   @Override
@@ -279,6 +291,10 @@ public final class ExecutePaymentTransaction implements ITransactionType, ITrans
 
   public interface _FinalStage {
     ExecutePaymentTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -359,6 +375,8 @@ public final class ExecutePaymentTransaction implements ITransactionType, ITrans
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -368,6 +386,7 @@ public final class ExecutePaymentTransaction implements ITransactionType, ITrans
     @Override
     public Builder from(ExecutePaymentTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -628,9 +647,29 @@ public final class ExecutePaymentTransaction implements ITransactionType, ITrans
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public ExecutePaymentTransaction build() {
-      return new ExecutePaymentTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, sourceMethod, destinationMethod, additionalProperties);
+      return new ExecutePaymentTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, sourceMethod, destinationMethod, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/resources/transactions/requests/ExecuteTradeTransaction.java
+++ b/java/src/main/java/com/pti/sdk/resources/transactions/requests/ExecuteTradeTransaction.java
@@ -36,6 +36,8 @@ import org.jetbrains.annotations.NotNull;
 public final class ExecuteTradeTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -70,15 +72,16 @@ public final class ExecuteTradeTransaction implements ITransactionType, ITransac
 
   private final Map<String, Object> additionalProperties;
 
-  private ExecuteTradeTransaction(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
-      String ptiRequestId, String ptiScenarioId, Optional<String> ptiSessionId,
-      Optional<Boolean> ptiDisableWebhook, Optional<String> ptiProviderName,
-      WalletPaymentMethod sourceMethod, WalletPaymentMethod destinationMethod,
-      Map<String, Object> additionalProperties) {
+  private ExecuteTradeTransaction(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta, String ptiRequestId, String ptiScenarioId,
+      Optional<String> ptiSessionId, Optional<Boolean> ptiDisableWebhook,
+      Optional<String> ptiProviderName, WalletPaymentMethod sourceMethod,
+      WalletPaymentMethod destinationMethod, Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -102,6 +105,15 @@ public final class ExecuteTradeTransaction implements ITransactionType, ITransac
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -229,12 +241,12 @@ public final class ExecuteTradeTransaction implements ITransactionType, ITransac
   }
 
   private boolean equalTo(ExecuteTradeTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && sourceMethod.equals(other.sourceMethod) && destinationMethod.equals(other.destinationMethod);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && sourceMethod.equals(other.sourceMethod) && destinationMethod.equals(other.destinationMethod);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.sourceMethod, this.destinationMethod);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.sourceMethod, this.destinationMethod);
   }
 
   @Override
@@ -282,6 +294,10 @@ public final class ExecuteTradeTransaction implements ITransactionType, ITransac
 
   public interface _FinalStage {
     ExecuteTradeTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -358,6 +374,8 @@ public final class ExecuteTradeTransaction implements ITransactionType, ITransac
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -367,6 +385,7 @@ public final class ExecuteTradeTransaction implements ITransactionType, ITransac
     @Override
     public Builder from(ExecuteTradeTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -618,9 +637,29 @@ public final class ExecuteTradeTransaction implements ITransactionType, ITransac
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public ExecuteTradeTransaction build() {
-      return new ExecuteTradeTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, sourceMethod, destinationMethod, additionalProperties);
+      return new ExecuteTradeTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, sourceMethod, destinationMethod, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/resources/transactions/requests/ExecuteTransferTransaction.java
+++ b/java/src/main/java/com/pti/sdk/resources/transactions/requests/ExecuteTransferTransaction.java
@@ -36,6 +36,8 @@ import org.jetbrains.annotations.NotNull;
 public final class ExecuteTransferTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -74,16 +76,17 @@ public final class ExecuteTransferTransaction implements ITransactionType, ITran
 
   private final Map<String, Object> additionalProperties;
 
-  private ExecuteTransferTransaction(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
-      String ptiRequestId, String ptiScenarioId, Optional<String> ptiSessionId,
-      Optional<Boolean> ptiDisableWebhook, Optional<String> ptiProviderName,
-      WalletPaymentMethod sourceTransferMethod, WalletPaymentMethod destinationTransferMethod,
-      OneOfUserSubTypes destination, Optional<String> destinationClientId,
-      Map<String, Object> additionalProperties) {
+  private ExecuteTransferTransaction(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta, String ptiRequestId, String ptiScenarioId,
+      Optional<String> ptiSessionId, Optional<Boolean> ptiDisableWebhook,
+      Optional<String> ptiProviderName, WalletPaymentMethod sourceTransferMethod,
+      WalletPaymentMethod destinationTransferMethod, OneOfUserSubTypes destination,
+      Optional<String> destinationClientId, Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -109,6 +112,15 @@ public final class ExecuteTransferTransaction implements ITransactionType, ITran
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -249,12 +261,12 @@ public final class ExecuteTransferTransaction implements ITransactionType, ITran
   }
 
   private boolean equalTo(ExecuteTransferTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && sourceTransferMethod.equals(other.sourceTransferMethod) && destinationTransferMethod.equals(other.destinationTransferMethod) && destination.equals(other.destination) && destinationClientId.equals(other.destinationClientId);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && sourceTransferMethod.equals(other.sourceTransferMethod) && destinationTransferMethod.equals(other.destinationTransferMethod) && destination.equals(other.destination) && destinationClientId.equals(other.destinationClientId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.sourceTransferMethod, this.destinationTransferMethod, this.destination, this.destinationClientId);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.sourceTransferMethod, this.destinationTransferMethod, this.destination, this.destinationClientId);
   }
 
   @Override
@@ -308,6 +320,10 @@ public final class ExecuteTransferTransaction implements ITransactionType, ITran
 
   public interface _FinalStage {
     ExecuteTransferTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -392,6 +408,8 @@ public final class ExecuteTransferTransaction implements ITransactionType, ITran
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -401,6 +419,7 @@ public final class ExecuteTransferTransaction implements ITransactionType, ITran
     @Override
     public Builder from(ExecuteTransferTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -683,9 +702,29 @@ public final class ExecuteTransferTransaction implements ITransactionType, ITran
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public ExecuteTransferTransaction build() {
-      return new ExecuteTransferTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, sourceTransferMethod, destinationTransferMethod, destination, destinationClientId, additionalProperties);
+      return new ExecuteTransferTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, sourceTransferMethod, destinationTransferMethod, destination, destinationClientId, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/resources/transactions/requests/ExecuteWithdrawalTransaction.java
+++ b/java/src/main/java/com/pti/sdk/resources/transactions/requests/ExecuteWithdrawalTransaction.java
@@ -37,6 +37,8 @@ import org.jetbrains.annotations.NotNull;
 public final class ExecuteWithdrawalTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -71,7 +73,7 @@ public final class ExecuteWithdrawalTransaction implements ITransactionType, ITr
 
   private final Map<String, Object> additionalProperties;
 
-  private ExecuteWithdrawalTransaction(TransactionTypeEnum type,
+  private ExecuteWithdrawalTransaction(TransactionTypeEnum type, Optional<String> id,
       Optional<String> transactionGroupId, Optional<String> subClientId,
       Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
       OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
@@ -80,6 +82,7 @@ public final class ExecuteWithdrawalTransaction implements ITransactionType, ITr
       Optional<String> ptiProviderName, OneOfExternalPaymentMethod destinationMethod,
       Optional<WalletPaymentMethod> sourceMethod, Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -103,6 +106,15 @@ public final class ExecuteWithdrawalTransaction implements ITransactionType, ITr
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -230,12 +242,12 @@ public final class ExecuteWithdrawalTransaction implements ITransactionType, ITr
   }
 
   private boolean equalTo(ExecuteWithdrawalTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && destinationMethod.equals(other.destinationMethod) && sourceMethod.equals(other.sourceMethod);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && ptiRequestId.equals(other.ptiRequestId) && ptiScenarioId.equals(other.ptiScenarioId) && ptiSessionId.equals(other.ptiSessionId) && ptiDisableWebhook.equals(other.ptiDisableWebhook) && ptiProviderName.equals(other.ptiProviderName) && destinationMethod.equals(other.destinationMethod) && sourceMethod.equals(other.sourceMethod);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.destinationMethod, this.sourceMethod);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.ptiRequestId, this.ptiScenarioId, this.ptiSessionId, this.ptiDisableWebhook, this.ptiProviderName, this.destinationMethod, this.sourceMethod);
   }
 
   @Override
@@ -279,6 +291,10 @@ public final class ExecuteWithdrawalTransaction implements ITransactionType, ITr
 
   public interface _FinalStage {
     ExecuteWithdrawalTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -359,6 +375,8 @@ public final class ExecuteWithdrawalTransaction implements ITransactionType, ITr
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -368,6 +386,7 @@ public final class ExecuteWithdrawalTransaction implements ITransactionType, ITr
     @Override
     public Builder from(ExecuteWithdrawalTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -628,9 +647,29 @@ public final class ExecuteWithdrawalTransaction implements ITransactionType, ITr
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public ExecuteWithdrawalTransaction build() {
-      return new ExecuteWithdrawalTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, destinationMethod, sourceMethod, additionalProperties);
+      return new ExecuteWithdrawalTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, ptiRequestId, ptiScenarioId, ptiSessionId, ptiDisableWebhook, ptiProviderName, destinationMethod, sourceMethod, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/resources/wallets/requests/WalletCreation.java
+++ b/java/src/main/java/com/pti/sdk/resources/wallets/requests/WalletCreation.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.NotNull;
     builder = WalletCreation.Builder.class
 )
 public final class WalletCreation {
-  private final Optional<String> walletId;
+  private final Optional<String> id;
 
   private final CurrencyEnum currency;
 
@@ -43,11 +43,11 @@ public final class WalletCreation {
 
   private final Map<String, Object> additionalProperties;
 
-  private WalletCreation(Optional<String> walletId, CurrencyEnum currency,
+  private WalletCreation(Optional<String> id, CurrencyEnum currency,
       Optional<BlockChainEnum> network, Optional<String> label,
       Optional<Boolean> multiWalletAddress, Optional<String> createDateTime,
       Map<String, Object> additionalProperties) {
-    this.walletId = walletId;
+    this.id = id;
     this.currency = currency;
     this.network = network;
     this.label = label;
@@ -56,9 +56,9 @@ public final class WalletCreation {
     this.additionalProperties = additionalProperties;
   }
 
-  @JsonProperty("walletId")
-  public Optional<String> getWalletId() {
-    return walletId;
+  @JsonProperty("id")
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("currency")
@@ -106,12 +106,12 @@ public final class WalletCreation {
   }
 
   private boolean equalTo(WalletCreation other) {
-    return walletId.equals(other.walletId) && currency.equals(other.currency) && network.equals(other.network) && label.equals(other.label) && multiWalletAddress.equals(other.multiWalletAddress) && createDateTime.equals(other.createDateTime);
+    return id.equals(other.id) && currency.equals(other.currency) && network.equals(other.network) && label.equals(other.label) && multiWalletAddress.equals(other.multiWalletAddress) && createDateTime.equals(other.createDateTime);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.walletId, this.currency, this.network, this.label, this.multiWalletAddress, this.createDateTime);
+    return Objects.hash(this.id, this.currency, this.network, this.label, this.multiWalletAddress, this.createDateTime);
   }
 
   @Override
@@ -132,9 +132,9 @@ public final class WalletCreation {
   public interface _FinalStage {
     WalletCreation build();
 
-    _FinalStage walletId(Optional<String> walletId);
+    _FinalStage id(Optional<String> id);
 
-    _FinalStage walletId(String walletId);
+    _FinalStage id(String id);
 
     _FinalStage network(Optional<BlockChainEnum> network);
 
@@ -167,7 +167,7 @@ public final class WalletCreation {
 
     private Optional<BlockChainEnum> network = Optional.empty();
 
-    private Optional<String> walletId = Optional.empty();
+    private Optional<String> id = Optional.empty();
 
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
@@ -177,7 +177,7 @@ public final class WalletCreation {
 
     @Override
     public Builder from(WalletCreation other) {
-      walletId(other.getWalletId());
+      id(other.getId());
       currency(other.getCurrency());
       network(other.getNetwork());
       label(other.getLabel());
@@ -262,24 +262,24 @@ public final class WalletCreation {
     }
 
     @Override
-    public _FinalStage walletId(String walletId) {
-      this.walletId = Optional.ofNullable(walletId);
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
       return this;
     }
 
     @Override
     @JsonSetter(
-        value = "walletId",
+        value = "id",
         nulls = Nulls.SKIP
     )
-    public _FinalStage walletId(Optional<String> walletId) {
-      this.walletId = walletId;
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
       return this;
     }
 
     @Override
     public WalletCreation build() {
-      return new WalletCreation(walletId, currency, network, label, multiWalletAddress, createDateTime, additionalProperties);
+      return new WalletCreation(id, currency, network, label, multiWalletAddress, createDateTime, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/types/BuyTransaction.java
+++ b/java/src/main/java/com/pti/sdk/types/BuyTransaction.java
@@ -29,6 +29,8 @@ import org.jetbrains.annotations.NotNull;
 public final class BuyTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -57,14 +59,15 @@ public final class BuyTransaction implements ITransactionType, ITransaction {
 
   private final Map<String, Object> additionalProperties;
 
-  private BuyTransaction(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
-      Optional<OneOfPaymentMethod> sourceMethod, Optional<OneOfPaymentMethod> destinationMethod,
-      Optional<DigitalItem> digitalItem, Optional<OneOfUserSubTypes> seller,
-      Map<String, Object> additionalProperties) {
+  private BuyTransaction(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta, Optional<OneOfPaymentMethod> sourceMethod,
+      Optional<OneOfPaymentMethod> destinationMethod, Optional<DigitalItem> digitalItem,
+      Optional<OneOfUserSubTypes> seller, Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -85,6 +88,15 @@ public final class BuyTransaction implements ITransactionType, ITransaction {
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -182,12 +194,12 @@ public final class BuyTransaction implements ITransactionType, ITransaction {
   }
 
   private boolean equalTo(BuyTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && sourceMethod.equals(other.sourceMethod) && destinationMethod.equals(other.destinationMethod) && digitalItem.equals(other.digitalItem) && seller.equals(other.seller);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && sourceMethod.equals(other.sourceMethod) && destinationMethod.equals(other.destinationMethod) && digitalItem.equals(other.digitalItem) && seller.equals(other.seller);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.sourceMethod, this.destinationMethod, this.digitalItem, this.seller);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.sourceMethod, this.destinationMethod, this.digitalItem, this.seller);
   }
 
   @Override
@@ -219,6 +231,10 @@ public final class BuyTransaction implements ITransactionType, ITransaction {
 
   public interface _FinalStage {
     BuyTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -293,6 +309,8 @@ public final class BuyTransaction implements ITransactionType, ITransaction {
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -302,6 +320,7 @@ public final class BuyTransaction implements ITransactionType, ITransaction {
     @Override
     public Builder from(BuyTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -518,9 +537,29 @@ public final class BuyTransaction implements ITransactionType, ITransaction {
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public BuyTransaction build() {
-      return new BuyTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, sourceMethod, destinationMethod, digitalItem, seller, additionalProperties);
+      return new BuyTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, sourceMethod, destinationMethod, digitalItem, seller, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/types/DepositTransaction.java
+++ b/java/src/main/java/com/pti/sdk/types/DepositTransaction.java
@@ -29,6 +29,8 @@ import org.jetbrains.annotations.NotNull;
 public final class DepositTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -53,13 +55,14 @@ public final class DepositTransaction implements ITransactionType, ITransaction 
 
   private final Map<String, Object> additionalProperties;
 
-  private DepositTransaction(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
-      Optional<OneOfPaymentMethod> sourceMethod, Optional<OneOfPaymentMethod> destinationMethod,
-      Map<String, Object> additionalProperties) {
+  private DepositTransaction(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta, Optional<OneOfPaymentMethod> sourceMethod,
+      Optional<OneOfPaymentMethod> destinationMethod, Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -78,6 +81,15 @@ public final class DepositTransaction implements ITransactionType, ITransaction 
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -165,12 +177,12 @@ public final class DepositTransaction implements ITransactionType, ITransaction 
   }
 
   private boolean equalTo(DepositTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && sourceMethod.equals(other.sourceMethod) && destinationMethod.equals(other.destinationMethod);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && sourceMethod.equals(other.sourceMethod) && destinationMethod.equals(other.destinationMethod);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.sourceMethod, this.destinationMethod);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.sourceMethod, this.destinationMethod);
   }
 
   @Override
@@ -202,6 +214,10 @@ public final class DepositTransaction implements ITransactionType, ITransaction 
 
   public interface _FinalStage {
     DepositTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -264,6 +280,8 @@ public final class DepositTransaction implements ITransactionType, ITransaction 
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -273,6 +291,7 @@ public final class DepositTransaction implements ITransactionType, ITransaction 
     @Override
     public Builder from(DepositTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -455,9 +474,29 @@ public final class DepositTransaction implements ITransactionType, ITransaction 
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public DepositTransaction build() {
-      return new DepositTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, sourceMethod, destinationMethod, additionalProperties);
+      return new DepositTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, sourceMethod, destinationMethod, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/types/DigitalItem.java
+++ b/java/src/main/java/com/pti/sdk/types/DigitalItem.java
@@ -27,6 +27,8 @@ import org.jetbrains.annotations.NotNull;
     builder = DigitalItem.Builder.class
 )
 public final class DigitalItem {
+  private final Optional<String> id;
+
   private final String itemReference;
 
   private final String itemTitle;
@@ -39,15 +41,21 @@ public final class DigitalItem {
 
   private final Map<String, Object> additionalProperties;
 
-  private DigitalItem(String itemReference, String itemTitle, String itemDescription,
-      Optional<Double> itemUsdValue, DigitalItemType digitalItemType,
+  private DigitalItem(Optional<String> id, String itemReference, String itemTitle,
+      String itemDescription, Optional<Double> itemUsdValue, DigitalItemType digitalItemType,
       Map<String, Object> additionalProperties) {
+    this.id = id;
     this.itemReference = itemReference;
     this.itemTitle = itemTitle;
     this.itemDescription = itemDescription;
     this.itemUsdValue = itemUsdValue;
     this.digitalItemType = digitalItemType;
     this.additionalProperties = additionalProperties;
+  }
+
+  @JsonProperty("id")
+  public Optional<String> getId() {
+    return id;
   }
 
   /**
@@ -99,12 +107,12 @@ public final class DigitalItem {
   }
 
   private boolean equalTo(DigitalItem other) {
-    return itemReference.equals(other.itemReference) && itemTitle.equals(other.itemTitle) && itemDescription.equals(other.itemDescription) && itemUsdValue.equals(other.itemUsdValue) && digitalItemType.equals(other.digitalItemType);
+    return id.equals(other.id) && itemReference.equals(other.itemReference) && itemTitle.equals(other.itemTitle) && itemDescription.equals(other.itemDescription) && itemUsdValue.equals(other.itemUsdValue) && digitalItemType.equals(other.digitalItemType);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.itemReference, this.itemTitle, this.itemDescription, this.itemUsdValue, this.digitalItemType);
+    return Objects.hash(this.id, this.itemReference, this.itemTitle, this.itemDescription, this.itemUsdValue, this.digitalItemType);
   }
 
   @Override
@@ -137,6 +145,10 @@ public final class DigitalItem {
   public interface _FinalStage {
     DigitalItem build();
 
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
+
     _FinalStage itemUsdValue(Optional<Double> itemUsdValue);
 
     _FinalStage itemUsdValue(Double itemUsdValue);
@@ -156,6 +168,8 @@ public final class DigitalItem {
 
     private Optional<Double> itemUsdValue = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -164,6 +178,7 @@ public final class DigitalItem {
 
     @Override
     public Builder from(DigitalItem other) {
+      id(other.getId());
       itemReference(other.getItemReference());
       itemTitle(other.getItemTitle());
       itemDescription(other.getItemDescription());
@@ -233,8 +248,24 @@ public final class DigitalItem {
     }
 
     @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
+    @Override
     public DigitalItem build() {
-      return new DigitalItem(itemReference, itemTitle, itemDescription, itemUsdValue, digitalItemType, additionalProperties);
+      return new DigitalItem(id, itemReference, itemTitle, itemDescription, itemUsdValue, digitalItemType, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/types/FeeRecipient.java
+++ b/java/src/main/java/com/pti/sdk/types/FeeRecipient.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.NotNull;
     builder = FeeRecipient.Builder.class
 )
 public final class FeeRecipient {
-  private final String feeRecipientId;
+  private final String id;
 
   private final String walletId;
 
@@ -36,9 +36,9 @@ public final class FeeRecipient {
 
   private final Map<String, Object> additionalProperties;
 
-  private FeeRecipient(String feeRecipientId, String walletId, String currency, double amount,
+  private FeeRecipient(String id, String walletId, String currency, double amount,
       FeeRecipientFeeRecipientType feeRecipientType, Map<String, Object> additionalProperties) {
-    this.feeRecipientId = feeRecipientId;
+    this.id = id;
     this.walletId = walletId;
     this.currency = currency;
     this.amount = amount;
@@ -49,9 +49,9 @@ public final class FeeRecipient {
   /**
    * @return User ID of the Commission Recipient
    */
-  @JsonProperty("feeRecipientId")
-  public String getFeeRecipientId() {
-    return feeRecipientId;
+  @JsonProperty("id")
+  public String getId() {
+    return id;
   }
 
   @JsonProperty("walletId")
@@ -86,12 +86,12 @@ public final class FeeRecipient {
   }
 
   private boolean equalTo(FeeRecipient other) {
-    return feeRecipientId.equals(other.feeRecipientId) && walletId.equals(other.walletId) && currency.equals(other.currency) && amount == other.amount && feeRecipientType.equals(other.feeRecipientType);
+    return id.equals(other.id) && walletId.equals(other.walletId) && currency.equals(other.currency) && amount == other.amount && feeRecipientType.equals(other.feeRecipientType);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.feeRecipientId, this.walletId, this.currency, this.amount, this.feeRecipientType);
+    return Objects.hash(this.id, this.walletId, this.currency, this.amount, this.feeRecipientType);
   }
 
   @Override
@@ -99,12 +99,12 @@ public final class FeeRecipient {
     return ObjectMappers.stringify(this);
   }
 
-  public static FeeRecipientIdStage builder() {
+  public static IdStage builder() {
     return new Builder();
   }
 
-  public interface FeeRecipientIdStage {
-    WalletIdStage feeRecipientId(@NotNull String feeRecipientId);
+  public interface IdStage {
+    WalletIdStage id(@NotNull String id);
 
     Builder from(FeeRecipient other);
   }
@@ -132,8 +132,8 @@ public final class FeeRecipient {
   @JsonIgnoreProperties(
       ignoreUnknown = true
   )
-  public static final class Builder implements FeeRecipientIdStage, WalletIdStage, CurrencyStage, AmountStage, FeeRecipientTypeStage, _FinalStage {
-    private String feeRecipientId;
+  public static final class Builder implements IdStage, WalletIdStage, CurrencyStage, AmountStage, FeeRecipientTypeStage, _FinalStage {
+    private String id;
 
     private String walletId;
 
@@ -151,7 +151,7 @@ public final class FeeRecipient {
 
     @Override
     public Builder from(FeeRecipient other) {
-      feeRecipientId(other.getFeeRecipientId());
+      id(other.getId());
       walletId(other.getWalletId());
       currency(other.getCurrency());
       amount(other.getAmount());
@@ -164,9 +164,9 @@ public final class FeeRecipient {
      * @return Reference to {@code this} so that method calls can be chained together.
      */
     @Override
-    @JsonSetter("feeRecipientId")
-    public WalletIdStage feeRecipientId(@NotNull String feeRecipientId) {
-      this.feeRecipientId = Objects.requireNonNull(feeRecipientId, "feeRecipientId must not be null");
+    @JsonSetter("id")
+    public WalletIdStage id(@NotNull String id) {
+      this.id = Objects.requireNonNull(id, "id must not be null");
       return this;
     }
 
@@ -200,7 +200,7 @@ public final class FeeRecipient {
 
     @Override
     public FeeRecipient build() {
-      return new FeeRecipient(feeRecipientId, walletId, currency, amount, feeRecipientType, additionalProperties);
+      return new FeeRecipient(id, walletId, currency, amount, feeRecipientType, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/types/ITransaction.java
+++ b/java/src/main/java/com/pti/sdk/types/ITransaction.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.Optional;
 
 public interface ITransaction {
+  Optional<String> getId();
+
   Optional<String> getTransactionGroupId();
 
   Optional<String> getSubClientId();

--- a/java/src/main/java/com/pti/sdk/types/MintTransaction.java
+++ b/java/src/main/java/com/pti/sdk/types/MintTransaction.java
@@ -29,6 +29,8 @@ import org.jetbrains.annotations.NotNull;
 public final class MintTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -53,13 +55,14 @@ public final class MintTransaction implements ITransactionType, ITransaction {
 
   private final Map<String, Object> additionalProperties;
 
-  private MintTransaction(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
-      Optional<OneOfUserSubTypes> destination, Optional<CryptoPaymentMethod> destinationMethod,
-      Map<String, Object> additionalProperties) {
+  private MintTransaction(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta, Optional<OneOfUserSubTypes> destination,
+      Optional<CryptoPaymentMethod> destinationMethod, Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -78,6 +81,15 @@ public final class MintTransaction implements ITransactionType, ITransaction {
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -165,12 +177,12 @@ public final class MintTransaction implements ITransactionType, ITransaction {
   }
 
   private boolean equalTo(MintTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && destination.equals(other.destination) && destinationMethod.equals(other.destinationMethod);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && destination.equals(other.destination) && destinationMethod.equals(other.destinationMethod);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.destination, this.destinationMethod);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.destination, this.destinationMethod);
   }
 
   @Override
@@ -202,6 +214,10 @@ public final class MintTransaction implements ITransactionType, ITransaction {
 
   public interface _FinalStage {
     MintTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -264,6 +280,8 @@ public final class MintTransaction implements ITransactionType, ITransaction {
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -273,6 +291,7 @@ public final class MintTransaction implements ITransactionType, ITransaction {
     @Override
     public Builder from(MintTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -455,9 +474,29 @@ public final class MintTransaction implements ITransactionType, ITransaction {
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public MintTransaction build() {
-      return new MintTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, destination, destinationMethod, additionalProperties);
+      return new MintTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, destination, destinationMethod, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/types/PaymentTransaction.java
+++ b/java/src/main/java/com/pti/sdk/types/PaymentTransaction.java
@@ -29,6 +29,8 @@ import org.jetbrains.annotations.NotNull;
 public final class PaymentTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -51,12 +53,14 @@ public final class PaymentTransaction implements ITransactionType, ITransaction 
 
   private final Map<String, Object> additionalProperties;
 
-  private PaymentTransaction(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
-      Optional<OneOfPaymentMethod> sourceMethod, Map<String, Object> additionalProperties) {
+  private PaymentTransaction(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta, Optional<OneOfPaymentMethod> sourceMethod,
+      Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -74,6 +78,15 @@ public final class PaymentTransaction implements ITransactionType, ITransaction 
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -156,12 +169,12 @@ public final class PaymentTransaction implements ITransactionType, ITransaction 
   }
 
   private boolean equalTo(PaymentTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && sourceMethod.equals(other.sourceMethod);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && sourceMethod.equals(other.sourceMethod);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.sourceMethod);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.sourceMethod);
   }
 
   @Override
@@ -193,6 +206,10 @@ public final class PaymentTransaction implements ITransactionType, ITransaction 
 
   public interface _FinalStage {
     PaymentTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -249,6 +266,8 @@ public final class PaymentTransaction implements ITransactionType, ITransaction 
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -258,6 +277,7 @@ public final class PaymentTransaction implements ITransactionType, ITransaction 
     @Override
     public Builder from(PaymentTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -423,9 +443,29 @@ public final class PaymentTransaction implements ITransactionType, ITransaction 
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public PaymentTransaction build() {
-      return new PaymentTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, sourceMethod, additionalProperties);
+      return new PaymentTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, sourceMethod, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/types/SellTransaction.java
+++ b/java/src/main/java/com/pti/sdk/types/SellTransaction.java
@@ -29,6 +29,8 @@ import org.jetbrains.annotations.NotNull;
 public final class SellTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -57,14 +59,15 @@ public final class SellTransaction implements ITransactionType, ITransaction {
 
   private final Map<String, Object> additionalProperties;
 
-  private SellTransaction(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
-      Optional<OneOfPaymentMethod> destinationMethod, Optional<OneOfPaymentMethod> sourceMethod,
-      Optional<DigitalItem> digitalItem, Optional<OneOfUserSubTypes> buyer,
-      Map<String, Object> additionalProperties) {
+  private SellTransaction(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta, Optional<OneOfPaymentMethod> destinationMethod,
+      Optional<OneOfPaymentMethod> sourceMethod, Optional<DigitalItem> digitalItem,
+      Optional<OneOfUserSubTypes> buyer, Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -85,6 +88,15 @@ public final class SellTransaction implements ITransactionType, ITransaction {
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -182,12 +194,12 @@ public final class SellTransaction implements ITransactionType, ITransaction {
   }
 
   private boolean equalTo(SellTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && destinationMethod.equals(other.destinationMethod) && sourceMethod.equals(other.sourceMethod) && digitalItem.equals(other.digitalItem) && buyer.equals(other.buyer);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && destinationMethod.equals(other.destinationMethod) && sourceMethod.equals(other.sourceMethod) && digitalItem.equals(other.digitalItem) && buyer.equals(other.buyer);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.destinationMethod, this.sourceMethod, this.digitalItem, this.buyer);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.destinationMethod, this.sourceMethod, this.digitalItem, this.buyer);
   }
 
   @Override
@@ -219,6 +231,10 @@ public final class SellTransaction implements ITransactionType, ITransaction {
 
   public interface _FinalStage {
     SellTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -293,6 +309,8 @@ public final class SellTransaction implements ITransactionType, ITransaction {
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -302,6 +320,7 @@ public final class SellTransaction implements ITransactionType, ITransaction {
     @Override
     public Builder from(SellTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -518,9 +537,29 @@ public final class SellTransaction implements ITransactionType, ITransaction {
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public SellTransaction build() {
-      return new SellTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, destinationMethod, sourceMethod, digitalItem, buyer, additionalProperties);
+      return new SellTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, destinationMethod, sourceMethod, digitalItem, buyer, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/types/TradeTransaction.java
+++ b/java/src/main/java/com/pti/sdk/types/TradeTransaction.java
@@ -29,6 +29,8 @@ import org.jetbrains.annotations.NotNull;
 public final class TradeTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -53,13 +55,15 @@ public final class TradeTransaction implements ITransactionType, ITransaction {
 
   private final Map<String, Object> additionalProperties;
 
-  private TradeTransaction(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
+  private TradeTransaction(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta,
       Optional<CryptoPaymentMethodDestination> destinationMethod,
       Optional<CryptoPaymentMethodSource> sourceMethod, Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -78,6 +82,15 @@ public final class TradeTransaction implements ITransactionType, ITransaction {
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -165,12 +178,12 @@ public final class TradeTransaction implements ITransactionType, ITransaction {
   }
 
   private boolean equalTo(TradeTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && destinationMethod.equals(other.destinationMethod) && sourceMethod.equals(other.sourceMethod);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && destinationMethod.equals(other.destinationMethod) && sourceMethod.equals(other.sourceMethod);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.destinationMethod, this.sourceMethod);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.destinationMethod, this.sourceMethod);
   }
 
   @Override
@@ -202,6 +215,10 @@ public final class TradeTransaction implements ITransactionType, ITransaction {
 
   public interface _FinalStage {
     TradeTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -264,6 +281,8 @@ public final class TradeTransaction implements ITransactionType, ITransaction {
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -273,6 +292,7 @@ public final class TradeTransaction implements ITransactionType, ITransaction {
     @Override
     public Builder from(TradeTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -456,9 +476,29 @@ public final class TradeTransaction implements ITransactionType, ITransaction {
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public TradeTransaction build() {
-      return new TradeTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, destinationMethod, sourceMethod, additionalProperties);
+      return new TradeTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, destinationMethod, sourceMethod, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/types/Transaction.java
+++ b/java/src/main/java/com/pti/sdk/types/Transaction.java
@@ -27,6 +27,8 @@ import org.jetbrains.annotations.NotNull;
     builder = Transaction.Builder.class
 )
 public final class Transaction implements ITransaction {
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -47,10 +49,12 @@ public final class Transaction implements ITransaction {
 
   private final Map<String, Object> additionalProperties;
 
-  private Transaction(Optional<String> transactionGroupId, Optional<String> subClientId,
-      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
-      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
-      Optional<Map<String, Object>> clientMeta, Map<String, Object> additionalProperties) {
+  private Transaction(Optional<String> id, Optional<String> transactionGroupId,
+      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
+      double amount, String date, OneOfUserSubTypes initiator,
+      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
+      Map<String, Object> additionalProperties) {
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -61,6 +65,15 @@ public final class Transaction implements ITransaction {
     this.ptiMeta = ptiMeta;
     this.clientMeta = clientMeta;
     this.additionalProperties = additionalProperties;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -138,12 +151,12 @@ public final class Transaction implements ITransaction {
   }
 
   private boolean equalTo(Transaction other) {
-    return transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta);
+    return id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta);
+    return Objects.hash(this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta);
   }
 
   @Override
@@ -171,6 +184,10 @@ public final class Transaction implements ITransaction {
 
   public interface _FinalStage {
     Transaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -219,6 +236,8 @@ public final class Transaction implements ITransaction {
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -227,6 +246,7 @@ public final class Transaction implements ITransaction {
 
     @Override
     public Builder from(Transaction other) {
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -368,9 +388,29 @@ public final class Transaction implements ITransaction {
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public Transaction build() {
-      return new Transaction(transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, additionalProperties);
+      return new Transaction(id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/types/TransactionType.java
+++ b/java/src/main/java/com/pti/sdk/types/TransactionType.java
@@ -29,6 +29,8 @@ import org.jetbrains.annotations.NotNull;
 public final class TransactionType implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -49,12 +51,13 @@ public final class TransactionType implements ITransactionType, ITransaction {
 
   private final Map<String, Object> additionalProperties;
 
-  private TransactionType(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
-      Map<String, Object> additionalProperties) {
+  private TransactionType(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta, Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -71,6 +74,15 @@ public final class TransactionType implements ITransactionType, ITransaction {
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -148,12 +160,12 @@ public final class TransactionType implements ITransactionType, ITransaction {
   }
 
   private boolean equalTo(TransactionType other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta);
   }
 
   @Override
@@ -185,6 +197,10 @@ public final class TransactionType implements ITransactionType, ITransaction {
 
   public interface _FinalStage {
     TransactionType build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -235,6 +251,8 @@ public final class TransactionType implements ITransactionType, ITransaction {
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -244,6 +262,7 @@ public final class TransactionType implements ITransactionType, ITransaction {
     @Override
     public Builder from(TransactionType other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -392,9 +411,29 @@ public final class TransactionType implements ITransactionType, ITransaction {
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public TransactionType build() {
-      return new TransactionType(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, additionalProperties);
+      return new TransactionType(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/types/TransferTransaction.java
+++ b/java/src/main/java/com/pti/sdk/types/TransferTransaction.java
@@ -29,6 +29,8 @@ import org.jetbrains.annotations.NotNull;
 public final class TransferTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -57,15 +59,16 @@ public final class TransferTransaction implements ITransactionType, ITransaction
 
   private final Map<String, Object> additionalProperties;
 
-  private TransferTransaction(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
-      Optional<OneOfPaymentMethod> sourceTransferMethod,
+  private TransferTransaction(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta, Optional<OneOfPaymentMethod> sourceTransferMethod,
       Optional<OneOfPaymentMethod> destinationTransferMethod,
       Optional<OneOfUserSubTypes> destination, Optional<String> destinationClientId,
       Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -86,6 +89,15 @@ public final class TransferTransaction implements ITransactionType, ITransaction
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -186,12 +198,12 @@ public final class TransferTransaction implements ITransactionType, ITransaction
   }
 
   private boolean equalTo(TransferTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && sourceTransferMethod.equals(other.sourceTransferMethod) && destinationTransferMethod.equals(other.destinationTransferMethod) && destination.equals(other.destination) && destinationClientId.equals(other.destinationClientId);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && sourceTransferMethod.equals(other.sourceTransferMethod) && destinationTransferMethod.equals(other.destinationTransferMethod) && destination.equals(other.destination) && destinationClientId.equals(other.destinationClientId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.sourceTransferMethod, this.destinationTransferMethod, this.destination, this.destinationClientId);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.sourceTransferMethod, this.destinationTransferMethod, this.destination, this.destinationClientId);
   }
 
   @Override
@@ -223,6 +235,10 @@ public final class TransferTransaction implements ITransactionType, ITransaction
 
   public interface _FinalStage {
     TransferTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -297,6 +313,8 @@ public final class TransferTransaction implements ITransactionType, ITransaction
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -306,6 +324,7 @@ public final class TransferTransaction implements ITransactionType, ITransaction
     @Override
     public Builder from(TransferTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -527,9 +546,29 @@ public final class TransferTransaction implements ITransactionType, ITransaction
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public TransferTransaction build() {
-      return new TransferTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, sourceTransferMethod, destinationTransferMethod, destination, destinationClientId, additionalProperties);
+      return new TransferTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, sourceTransferMethod, destinationTransferMethod, destination, destinationClientId, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/types/Wallet.java
+++ b/java/src/main/java/com/pti/sdk/types/Wallet.java
@@ -27,7 +27,7 @@ import java.util.Optional;
     builder = Wallet.Builder.class
 )
 public final class Wallet {
-  private final Optional<String> walletId;
+  private final Optional<String> id;
 
   private final Optional<String> label;
 
@@ -53,13 +53,13 @@ public final class Wallet {
 
   private final Map<String, Object> additionalProperties;
 
-  private Wallet(Optional<String> walletId, Optional<String> label, Optional<CurrencyEnum> currency,
+  private Wallet(Optional<String> id, Optional<String> label, Optional<CurrencyEnum> currency,
       Optional<BlockChainEnum> network, Optional<Double> availableBalance,
       Optional<Double> lockedBalance, Optional<Double> pendingBalance,
       Optional<Double> totalBalance, Optional<Map<String, Object>> depositInstruction,
       Optional<String> createDateTime, Optional<Boolean> multiWalletAddress, Optional<String> type,
       Map<String, Object> additionalProperties) {
-    this.walletId = walletId;
+    this.id = id;
     this.label = label;
     this.currency = currency;
     this.network = network;
@@ -74,9 +74,9 @@ public final class Wallet {
     this.additionalProperties = additionalProperties;
   }
 
-  @JsonProperty("walletId")
-  public Optional<String> getWalletId() {
-    return walletId;
+  @JsonProperty("id")
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("label")
@@ -149,12 +149,12 @@ public final class Wallet {
   }
 
   private boolean equalTo(Wallet other) {
-    return walletId.equals(other.walletId) && label.equals(other.label) && currency.equals(other.currency) && network.equals(other.network) && availableBalance.equals(other.availableBalance) && lockedBalance.equals(other.lockedBalance) && pendingBalance.equals(other.pendingBalance) && totalBalance.equals(other.totalBalance) && depositInstruction.equals(other.depositInstruction) && createDateTime.equals(other.createDateTime) && multiWalletAddress.equals(other.multiWalletAddress) && type.equals(other.type);
+    return id.equals(other.id) && label.equals(other.label) && currency.equals(other.currency) && network.equals(other.network) && availableBalance.equals(other.availableBalance) && lockedBalance.equals(other.lockedBalance) && pendingBalance.equals(other.pendingBalance) && totalBalance.equals(other.totalBalance) && depositInstruction.equals(other.depositInstruction) && createDateTime.equals(other.createDateTime) && multiWalletAddress.equals(other.multiWalletAddress) && type.equals(other.type);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.walletId, this.label, this.currency, this.network, this.availableBalance, this.lockedBalance, this.pendingBalance, this.totalBalance, this.depositInstruction, this.createDateTime, this.multiWalletAddress, this.type);
+    return Objects.hash(this.id, this.label, this.currency, this.network, this.availableBalance, this.lockedBalance, this.pendingBalance, this.totalBalance, this.depositInstruction, this.createDateTime, this.multiWalletAddress, this.type);
   }
 
   @Override
@@ -170,7 +170,7 @@ public final class Wallet {
       ignoreUnknown = true
   )
   public static final class Builder {
-    private Optional<String> walletId = Optional.empty();
+    private Optional<String> id = Optional.empty();
 
     private Optional<String> label = Optional.empty();
 
@@ -201,7 +201,7 @@ public final class Wallet {
     }
 
     public Builder from(Wallet other) {
-      walletId(other.getWalletId());
+      id(other.getId());
       label(other.getLabel());
       currency(other.getCurrency());
       network(other.getNetwork());
@@ -217,16 +217,16 @@ public final class Wallet {
     }
 
     @JsonSetter(
-        value = "walletId",
+        value = "id",
         nulls = Nulls.SKIP
     )
-    public Builder walletId(Optional<String> walletId) {
-      this.walletId = walletId;
+    public Builder id(Optional<String> id) {
+      this.id = id;
       return this;
     }
 
-    public Builder walletId(String walletId) {
-      this.walletId = Optional.ofNullable(walletId);
+    public Builder id(String id) {
+      this.id = Optional.ofNullable(id);
       return this;
     }
 
@@ -385,7 +385,7 @@ public final class Wallet {
     }
 
     public Wallet build() {
-      return new Wallet(walletId, label, currency, network, availableBalance, lockedBalance, pendingBalance, totalBalance, depositInstruction, createDateTime, multiWalletAddress, type, additionalProperties);
+      return new Wallet(id, label, currency, network, availableBalance, lockedBalance, pendingBalance, totalBalance, depositInstruction, createDateTime, multiWalletAddress, type, additionalProperties);
     }
   }
 }

--- a/java/src/main/java/com/pti/sdk/types/WithdrawalTransaction.java
+++ b/java/src/main/java/com/pti/sdk/types/WithdrawalTransaction.java
@@ -29,6 +29,8 @@ import org.jetbrains.annotations.NotNull;
 public final class WithdrawalTransaction implements ITransactionType, ITransaction {
   private final TransactionTypeEnum type;
 
+  private final Optional<String> id;
+
   private final Optional<String> transactionGroupId;
 
   private final Optional<String> subClientId;
@@ -53,13 +55,14 @@ public final class WithdrawalTransaction implements ITransactionType, ITransacti
 
   private final Map<String, Object> additionalProperties;
 
-  private WithdrawalTransaction(TransactionTypeEnum type, Optional<String> transactionGroupId,
-      Optional<String> subClientId, Optional<Total> transactionTotal, Optional<Double> usdValue,
-      double amount, String date, OneOfUserSubTypes initiator,
-      Optional<Map<String, Object>> ptiMeta, Optional<Map<String, Object>> clientMeta,
-      Optional<OneOfPaymentMethod> destinationMethod, Optional<OneOfPaymentMethod> sourceMethod,
-      Map<String, Object> additionalProperties) {
+  private WithdrawalTransaction(TransactionTypeEnum type, Optional<String> id,
+      Optional<String> transactionGroupId, Optional<String> subClientId,
+      Optional<Total> transactionTotal, Optional<Double> usdValue, double amount, String date,
+      OneOfUserSubTypes initiator, Optional<Map<String, Object>> ptiMeta,
+      Optional<Map<String, Object>> clientMeta, Optional<OneOfPaymentMethod> destinationMethod,
+      Optional<OneOfPaymentMethod> sourceMethod, Map<String, Object> additionalProperties) {
     this.type = type;
+    this.id = id;
     this.transactionGroupId = transactionGroupId;
     this.subClientId = subClientId;
     this.transactionTotal = transactionTotal;
@@ -78,6 +81,15 @@ public final class WithdrawalTransaction implements ITransactionType, ITransacti
   @Override
   public TransactionTypeEnum getType() {
     return type;
+  }
+
+  /**
+   * @return The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.
+   */
+  @JsonProperty("id")
+  @Override
+  public Optional<String> getId() {
+    return id;
   }
 
   @JsonProperty("transactionGroupId")
@@ -165,12 +177,12 @@ public final class WithdrawalTransaction implements ITransactionType, ITransacti
   }
 
   private boolean equalTo(WithdrawalTransaction other) {
-    return type.equals(other.type) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && destinationMethod.equals(other.destinationMethod) && sourceMethod.equals(other.sourceMethod);
+    return type.equals(other.type) && id.equals(other.id) && transactionGroupId.equals(other.transactionGroupId) && subClientId.equals(other.subClientId) && transactionTotal.equals(other.transactionTotal) && usdValue.equals(other.usdValue) && amount == other.amount && date.equals(other.date) && initiator.equals(other.initiator) && ptiMeta.equals(other.ptiMeta) && clientMeta.equals(other.clientMeta) && destinationMethod.equals(other.destinationMethod) && sourceMethod.equals(other.sourceMethod);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.type, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.destinationMethod, this.sourceMethod);
+    return Objects.hash(this.type, this.id, this.transactionGroupId, this.subClientId, this.transactionTotal, this.usdValue, this.amount, this.date, this.initiator, this.ptiMeta, this.clientMeta, this.destinationMethod, this.sourceMethod);
   }
 
   @Override
@@ -202,6 +214,10 @@ public final class WithdrawalTransaction implements ITransactionType, ITransacti
 
   public interface _FinalStage {
     WithdrawalTransaction build();
+
+    _FinalStage id(Optional<String> id);
+
+    _FinalStage id(String id);
 
     _FinalStage transactionGroupId(Optional<String> transactionGroupId);
 
@@ -264,6 +280,8 @@ public final class WithdrawalTransaction implements ITransactionType, ITransacti
 
     private Optional<String> transactionGroupId = Optional.empty();
 
+    private Optional<String> id = Optional.empty();
+
     @JsonAnySetter
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -273,6 +291,7 @@ public final class WithdrawalTransaction implements ITransactionType, ITransacti
     @Override
     public Builder from(WithdrawalTransaction other) {
       type(other.getType());
+      id(other.getId());
       transactionGroupId(other.getTransactionGroupId());
       subClientId(other.getSubClientId());
       transactionTotal(other.getTransactionTotal());
@@ -455,9 +474,29 @@ public final class WithdrawalTransaction implements ITransactionType, ITransacti
       return this;
     }
 
+    /**
+     * <p>The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header.</p>
+     * @return Reference to {@code this} so that method calls can be chained together.
+     */
+    @Override
+    public _FinalStage id(String id) {
+      this.id = Optional.ofNullable(id);
+      return this;
+    }
+
+    @Override
+    @JsonSetter(
+        value = "id",
+        nulls = Nulls.SKIP
+    )
+    public _FinalStage id(Optional<String> id) {
+      this.id = id;
+      return this;
+    }
+
     @Override
     public WithdrawalTransaction build() {
-      return new WithdrawalTransaction(type, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, destinationMethod, sourceMethod, additionalProperties);
+      return new WithdrawalTransaction(type, id, transactionGroupId, subClientId, transactionTotal, usdValue, amount, date, initiator, ptiMeta, clientMeta, destinationMethod, sourceMethod, additionalProperties);
     }
   }
 }

--- a/ts/src/api/resources/marketplace/client/Client.d.ts
+++ b/ts/src/api/resources/marketplace/client/Client.d.ts
@@ -65,6 +65,7 @@ export declare class Marketplace {
      *         sourceMethod: {
      *             paymentMethodType: "CRYPTO",
      *             paymentInformation: {
+     *                 id: "1de3e77b-e673-4e44-8b69-4931364c4e76",
      *                 walletAddress: "walletAddress",
      *                 currency: "currency",
      *                 network: "network"
@@ -123,6 +124,7 @@ export declare class Marketplace {
      *         destinationMethod: {
      *             paymentMethodType: "CRYPTO",
      *             paymentInformation: {
+     *                 id: "c5b2cca7-a1ac-4aad-a461-be8903c695d9",
      *                 walletAddress: "walletAddress",
      *                 currency: "currency",
      *                 network: "network"

--- a/ts/src/api/resources/marketplace/client/Client.js
+++ b/ts/src/api/resources/marketplace/client/Client.js
@@ -100,6 +100,7 @@ class Marketplace {
      *         sourceMethod: {
      *             paymentMethodType: "CRYPTO",
      *             paymentInformation: {
+     *                 id: "1de3e77b-e673-4e44-8b69-4931364c4e76",
      *                 walletAddress: "walletAddress",
      *                 currency: "currency",
      *                 network: "network"
@@ -243,6 +244,7 @@ class Marketplace {
      *         destinationMethod: {
      *             paymentMethodType: "CRYPTO",
      *             paymentInformation: {
+     *                 id: "c5b2cca7-a1ac-4aad-a461-be8903c695d9",
      *                 walletAddress: "walletAddress",
      *                 currency: "currency",
      *                 network: "network"

--- a/ts/src/api/resources/marketplace/client/requests/ExecuteBuyTransaction.d.ts
+++ b/ts/src/api/resources/marketplace/client/requests/ExecuteBuyTransaction.d.ts
@@ -30,6 +30,7 @@ import * as PTI from "../../../../index";
  *         sourceMethod: {
  *             paymentMethodType: "CRYPTO",
  *             paymentInformation: {
+ *                 id: "1de3e77b-e673-4e44-8b69-4931364c4e76",
  *                 walletAddress: "walletAddress",
  *                 currency: "currency",
  *                 network: "network"

--- a/ts/src/api/resources/marketplace/client/requests/ExecuteSellTransaction.d.ts
+++ b/ts/src/api/resources/marketplace/client/requests/ExecuteSellTransaction.d.ts
@@ -30,6 +30,7 @@ import * as PTI from "../../../../index";
  *         destinationMethod: {
  *             paymentMethodType: "CRYPTO",
  *             paymentInformation: {
+ *                 id: "c5b2cca7-a1ac-4aad-a461-be8903c695d9",
  *                 walletAddress: "walletAddress",
  *                 currency: "currency",
  *                 network: "network"

--- a/ts/src/api/resources/transactions/client/Client.d.ts
+++ b/ts/src/api/resources/transactions/client/Client.d.ts
@@ -164,7 +164,10 @@ export declare class Transactions {
      *             }
      *         },
      *         destinationMethod: {
-     *             billingEmail: "user@example.com"
+     *             billingEmail: "user@example.com",
+     *             paymentInformation: {
+     *                 id: "3f8d7e96-5d63-49b4-b4a8-42c70ef0cc82"
+     *             }
      *         }
      *     })
      */
@@ -210,7 +213,7 @@ export declare class Transactions {
      *         },
      *         sourceMethod: {
      *             paymentInformation: {
-     *                 walletId: "a8e99100-f562-4e5b-b86f-9142dc2bc9f0",
+     *                 id: "a8e99100-f562-4e5b-b86f-9142dc2bc9f0",
      *                 type: "WALLET"
      *             }
      *         }
@@ -276,7 +279,7 @@ export declare class Transactions {
      *         },
      *         destinationMethod: {
      *             paymentInformation: {
-     *                 walletId: "e13c3242-57d3-473f-b98c-eb2768e4549c",
+     *                 id: "e13c3242-57d3-473f-b98c-eb2768e4549c",
      *                 type: "WALLET"
      *             }
      *         }
@@ -316,13 +319,13 @@ export declare class Transactions {
      *         type: PTI.TransactionTypeEnum.Transfer,
      *         sourceTransferMethod: {
      *             paymentInformation: {
-     *                 walletId: "dd2473b7-1afd-4f9c-a359-b4294587fef6",
+     *                 id: "dd2473b7-1afd-4f9c-a359-b4294587fef6",
      *                 type: "WALLET"
      *             }
      *         },
      *         destinationTransferMethod: {
      *             paymentInformation: {
-     *                 walletId: "70cd9757-f288-41e5-8506-5c38b7c819e1",
+     *                 id: "70cd9757-f288-41e5-8506-5c38b7c819e1",
      *                 type: "WALLET"
      *             }
      *         },
@@ -372,13 +375,13 @@ export declare class Transactions {
      *         type: PTI.TransactionTypeEnum.Trade,
      *         sourceMethod: {
      *             paymentInformation: {
-     *                 walletId: "MySOLWallet",
+     *                 id: "MySOLWallet",
      *                 type: "WALLET"
      *             }
      *         },
      *         destinationMethod: {
      *             paymentInformation: {
-     *                 walletId: "MyUSDWallet",
+     *                 id: "MyUSDWallet",
      *                 type: "WALLET"
      *             }
      *         }
@@ -428,7 +431,7 @@ export declare class Transactions {
      *         },
      *         destinationMethod: {
      *             paymentInformation: {
-     *                 walletId: "MyBTCWallet",
+     *                 id: "MyBTCWallet",
      *                 type: "WALLET"
      *             }
      *         }

--- a/ts/src/api/resources/transactions/client/Client.js
+++ b/ts/src/api/resources/transactions/client/Client.js
@@ -271,7 +271,10 @@ class Transactions {
      *             }
      *         },
      *         destinationMethod: {
-     *             billingEmail: "user@example.com"
+     *             billingEmail: "user@example.com",
+     *             paymentInformation: {
+     *                 id: "3f8d7e96-5d63-49b4-b4a8-42c70ef0cc82"
+     *             }
      *         }
      *     })
      */
@@ -402,7 +405,7 @@ class Transactions {
      *         },
      *         sourceMethod: {
      *             paymentInformation: {
-     *                 walletId: "a8e99100-f562-4e5b-b86f-9142dc2bc9f0",
+     *                 id: "a8e99100-f562-4e5b-b86f-9142dc2bc9f0",
      *                 type: "WALLET"
      *             }
      *         }
@@ -553,7 +556,7 @@ class Transactions {
      *         },
      *         destinationMethod: {
      *             paymentInformation: {
-     *                 walletId: "e13c3242-57d3-473f-b98c-eb2768e4549c",
+     *                 id: "e13c3242-57d3-473f-b98c-eb2768e4549c",
      *                 type: "WALLET"
      *             }
      *         }
@@ -678,13 +681,13 @@ class Transactions {
      *         type: PTI.TransactionTypeEnum.Transfer,
      *         sourceTransferMethod: {
      *             paymentInformation: {
-     *                 walletId: "dd2473b7-1afd-4f9c-a359-b4294587fef6",
+     *                 id: "dd2473b7-1afd-4f9c-a359-b4294587fef6",
      *                 type: "WALLET"
      *             }
      *         },
      *         destinationTransferMethod: {
      *             paymentInformation: {
-     *                 walletId: "70cd9757-f288-41e5-8506-5c38b7c819e1",
+     *                 id: "70cd9757-f288-41e5-8506-5c38b7c819e1",
      *                 type: "WALLET"
      *             }
      *         },
@@ -819,13 +822,13 @@ class Transactions {
      *         type: PTI.TransactionTypeEnum.Trade,
      *         sourceMethod: {
      *             paymentInformation: {
-     *                 walletId: "MySOLWallet",
+     *                 id: "MySOLWallet",
      *                 type: "WALLET"
      *             }
      *         },
      *         destinationMethod: {
      *             paymentInformation: {
-     *                 walletId: "MyUSDWallet",
+     *                 id: "MyUSDWallet",
      *                 type: "WALLET"
      *             }
      *         }
@@ -960,7 +963,7 @@ class Transactions {
      *         },
      *         destinationMethod: {
      *             paymentInformation: {
-     *                 walletId: "MyBTCWallet",
+     *                 id: "MyBTCWallet",
      *                 type: "WALLET"
      *             }
      *         }

--- a/ts/src/api/resources/transactions/client/requests/ExecuteDepositTransaction.d.ts
+++ b/ts/src/api/resources/transactions/client/requests/ExecuteDepositTransaction.d.ts
@@ -51,7 +51,10 @@ import * as PTI from "../../../../index";
  *             }
  *         },
  *         destinationMethod: {
- *             billingEmail: "user@example.com"
+ *             billingEmail: "user@example.com",
+ *             paymentInformation: {
+ *                 id: "3f8d7e96-5d63-49b4-b4a8-42c70ef0cc82"
+ *             }
  *         }
  *     }
  */

--- a/ts/src/api/resources/transactions/client/requests/ExecuteMintTransaction.d.ts
+++ b/ts/src/api/resources/transactions/client/requests/ExecuteMintTransaction.d.ts
@@ -33,7 +33,7 @@ import * as PTI from "../../../../index";
  *         },
  *         destinationMethod: {
  *             paymentInformation: {
- *                 walletId: "MyBTCWallet",
+ *                 id: "MyBTCWallet",
  *                 type: "WALLET"
  *             }
  *         }

--- a/ts/src/api/resources/transactions/client/requests/ExecutePaymentTransaction.d.ts
+++ b/ts/src/api/resources/transactions/client/requests/ExecutePaymentTransaction.d.ts
@@ -49,7 +49,7 @@ import * as PTI from "../../../../index";
  *         },
  *         destinationMethod: {
  *             paymentInformation: {
- *                 walletId: "e13c3242-57d3-473f-b98c-eb2768e4549c",
+ *                 id: "e13c3242-57d3-473f-b98c-eb2768e4549c",
  *                 type: "WALLET"
  *             }
  *         }

--- a/ts/src/api/resources/transactions/client/requests/ExecuteTradeTransaction.d.ts
+++ b/ts/src/api/resources/transactions/client/requests/ExecuteTradeTransaction.d.ts
@@ -23,13 +23,13 @@ import * as PTI from "../../../../index";
  *         type: PTI.TransactionTypeEnum.Trade,
  *         sourceMethod: {
  *             paymentInformation: {
- *                 walletId: "MySOLWallet",
+ *                 id: "MySOLWallet",
  *                 type: "WALLET"
  *             }
  *         },
  *         destinationMethod: {
  *             paymentInformation: {
- *                 walletId: "MyUSDWallet",
+ *                 id: "MyUSDWallet",
  *                 type: "WALLET"
  *             }
  *         }

--- a/ts/src/api/resources/transactions/client/requests/ExecuteTransferTransaction.d.ts
+++ b/ts/src/api/resources/transactions/client/requests/ExecuteTransferTransaction.d.ts
@@ -23,13 +23,13 @@ import * as PTI from "../../../../index";
  *         type: PTI.TransactionTypeEnum.Transfer,
  *         sourceTransferMethod: {
  *             paymentInformation: {
- *                 walletId: "dd2473b7-1afd-4f9c-a359-b4294587fef6",
+ *                 id: "dd2473b7-1afd-4f9c-a359-b4294587fef6",
  *                 type: "WALLET"
  *             }
  *         },
  *         destinationTransferMethod: {
  *             paymentInformation: {
- *                 walletId: "70cd9757-f288-41e5-8506-5c38b7c819e1",
+ *                 id: "70cd9757-f288-41e5-8506-5c38b7c819e1",
  *                 type: "WALLET"
  *             }
  *         },

--- a/ts/src/api/resources/transactions/client/requests/ExecuteWithdrawalTransaction.d.ts
+++ b/ts/src/api/resources/transactions/client/requests/ExecuteWithdrawalTransaction.d.ts
@@ -31,7 +31,7 @@ import * as PTI from "../../../../index";
  *         },
  *         sourceMethod: {
  *             paymentInformation: {
- *                 walletId: "a8e99100-f562-4e5b-b86f-9142dc2bc9f0",
+ *                 id: "a8e99100-f562-4e5b-b86f-9142dc2bc9f0",
  *                 type: "WALLET"
  *             }
  *         }

--- a/ts/src/api/resources/wallets/client/Client.d.ts
+++ b/ts/src/api/resources/wallets/client/Client.d.ts
@@ -59,7 +59,7 @@ export declare class Wallets {
      *
      * @example
      *     await client.wallets.createWallet("userId", {
-     *         walletId: "c8768405-6129-4bda-8a10-8ef234dff30e",
+     *         id: "c8768405-6129-4bda-8a10-8ef234dff30e",
      *         currency: PTI.CurrencyEnum.Eth,
      *         network: PTI.BlockChainEnum.Ethereum
      *     })

--- a/ts/src/api/resources/wallets/client/Client.js
+++ b/ts/src/api/resources/wallets/client/Client.js
@@ -205,7 +205,7 @@ class Wallets {
      *
      * @example
      *     await client.wallets.createWallet("userId", {
-     *         walletId: "c8768405-6129-4bda-8a10-8ef234dff30e",
+     *         id: "c8768405-6129-4bda-8a10-8ef234dff30e",
      *         currency: PTI.CurrencyEnum.Eth,
      *         network: PTI.BlockChainEnum.Ethereum
      *     })

--- a/ts/src/api/resources/wallets/client/requests/WalletCreation.d.ts
+++ b/ts/src/api/resources/wallets/client/requests/WalletCreation.d.ts
@@ -5,13 +5,13 @@ import * as PTI from "../../../../index";
 /**
  * @example
  *     {
- *         walletId: "c8768405-6129-4bda-8a10-8ef234dff30e",
+ *         id: "c8768405-6129-4bda-8a10-8ef234dff30e",
  *         currency: PTI.CurrencyEnum.Eth,
  *         network: PTI.BlockChainEnum.Ethereum
  *     }
  */
 export interface WalletCreation {
-    walletId?: string;
+    id?: string;
     currency: PTI.CurrencyEnum;
     network?: PTI.BlockChainEnum;
     /** Optional readable label */

--- a/ts/src/api/types/DigitalItem.d.ts
+++ b/ts/src/api/types/DigitalItem.d.ts
@@ -3,6 +3,7 @@
  */
 import * as PTI from "../index";
 export interface DigitalItem {
+    id?: PTI.UuidLikeStr;
     /** Reference information about the item, for example could be the contract address of an NFT item. */
     itemReference: string;
     /** The name of the item, for example: ShaggyDog#2 */

--- a/ts/src/api/types/FeeRecipient.d.ts
+++ b/ts/src/api/types/FeeRecipient.d.ts
@@ -4,7 +4,7 @@
 import * as PTI from "../index";
 export interface FeeRecipient {
     /** User ID of the Commission Recipient */
-    feeRecipientId: string;
+    id: string;
     walletId: string;
     currency: string;
     amount: number;

--- a/ts/src/api/types/Transaction.d.ts
+++ b/ts/src/api/types/Transaction.d.ts
@@ -6,6 +6,8 @@ import * as PTI from "../index";
  * The `transactionTotal` field will be assumed to be all zeroes if not provided. If no currency has been provided `USD` will be used. If no amount has been provided `0` will be used
  */
 export interface Transaction {
+    /** The id of the transaction/payment. Optional, will be populated with the value provided in the x-pti-request-id header. */
+    id?: string;
     transactionGroupId?: PTI.UuidLikeStrTransactionGroup;
     subClientId?: PTI.UuidLikeStrSubClient;
     transactionTotal?: PTI.Total;

--- a/ts/src/api/types/Wallet.d.ts
+++ b/ts/src/api/types/Wallet.d.ts
@@ -3,7 +3,7 @@
  */
 import * as PTI from "../index";
 export interface Wallet {
-    walletId?: string;
+    id?: string;
     label?: string;
     currency?: PTI.CurrencyEnum;
     network?: PTI.BlockChainEnum;

--- a/ts/src/serialization/resources/wallets/client/requests/WalletCreation.d.ts
+++ b/ts/src/serialization/resources/wallets/client/requests/WalletCreation.d.ts
@@ -9,7 +9,7 @@ import { BlockChainEnum } from "../../../../types/BlockChainEnum";
 export declare const WalletCreation: core.serialization.Schema<serializers.WalletCreation.Raw, PTI.WalletCreation>;
 export declare namespace WalletCreation {
     interface Raw {
-        walletId?: string | null;
+        id?: string | null;
         currency: CurrencyEnum.Raw;
         network?: BlockChainEnum.Raw | null;
         label?: string | null;

--- a/ts/src/serialization/resources/wallets/client/requests/WalletCreation.js
+++ b/ts/src/serialization/resources/wallets/client/requests/WalletCreation.js
@@ -31,7 +31,7 @@ const core = __importStar(require("../../../../../core"));
 const CurrencyEnum_1 = require("../../../../types/CurrencyEnum");
 const BlockChainEnum_1 = require("../../../../types/BlockChainEnum");
 exports.WalletCreation = core.serialization.object({
-    walletId: core.serialization.string().optional(),
+    id: core.serialization.string().optional(),
     currency: CurrencyEnum_1.CurrencyEnum,
     network: BlockChainEnum_1.BlockChainEnum.optional(),
     label: core.serialization.string().optional(),

--- a/ts/src/serialization/types/DigitalItem.d.ts
+++ b/ts/src/serialization/types/DigitalItem.d.ts
@@ -4,10 +4,12 @@
 import * as serializers from "../index";
 import * as PTI from "../../api/index";
 import * as core from "../../core";
+import { UuidLikeStr } from "./UuidLikeStr";
 import { DigitalItemType } from "./DigitalItemType";
 export declare const DigitalItem: core.serialization.ObjectSchema<serializers.DigitalItem.Raw, PTI.DigitalItem>;
 export declare namespace DigitalItem {
     interface Raw {
+        id?: UuidLikeStr.Raw | null;
         itemReference: string;
         itemTitle: string;
         itemDescription: string;

--- a/ts/src/serialization/types/DigitalItem.js
+++ b/ts/src/serialization/types/DigitalItem.js
@@ -28,8 +28,10 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.DigitalItem = void 0;
 const core = __importStar(require("../../core"));
+const UuidLikeStr_1 = require("./UuidLikeStr");
 const DigitalItemType_1 = require("./DigitalItemType");
 exports.DigitalItem = core.serialization.object({
+    id: UuidLikeStr_1.UuidLikeStr.optional(),
     itemReference: core.serialization.string(),
     itemTitle: core.serialization.string(),
     itemDescription: core.serialization.string(),

--- a/ts/src/serialization/types/FeeRecipient.d.ts
+++ b/ts/src/serialization/types/FeeRecipient.d.ts
@@ -8,7 +8,7 @@ import { FeeRecipientFeeRecipientType } from "./FeeRecipientFeeRecipientType";
 export declare const FeeRecipient: core.serialization.ObjectSchema<serializers.FeeRecipient.Raw, PTI.FeeRecipient>;
 export declare namespace FeeRecipient {
     interface Raw {
-        feeRecipientId: string;
+        id: string;
         walletId: string;
         currency: string;
         amount: number;

--- a/ts/src/serialization/types/FeeRecipient.js
+++ b/ts/src/serialization/types/FeeRecipient.js
@@ -30,7 +30,7 @@ exports.FeeRecipient = void 0;
 const core = __importStar(require("../../core"));
 const FeeRecipientFeeRecipientType_1 = require("./FeeRecipientFeeRecipientType");
 exports.FeeRecipient = core.serialization.object({
-    feeRecipientId: core.serialization.string(),
+    id: core.serialization.string(),
     walletId: core.serialization.string(),
     currency: core.serialization.string(),
     amount: core.serialization.number(),

--- a/ts/src/serialization/types/Transaction.d.ts
+++ b/ts/src/serialization/types/Transaction.d.ts
@@ -11,6 +11,7 @@ import { OneOfUserSubTypes } from "./OneOfUserSubTypes";
 export declare const Transaction: core.serialization.ObjectSchema<serializers.Transaction.Raw, PTI.Transaction>;
 export declare namespace Transaction {
     interface Raw {
+        id?: string | null;
         transactionGroupId?: UuidLikeStrTransactionGroup.Raw | null;
         subClientId?: UuidLikeStrSubClient.Raw | null;
         transactionTotal?: Total.Raw | null;

--- a/ts/src/serialization/types/Transaction.js
+++ b/ts/src/serialization/types/Transaction.js
@@ -33,6 +33,7 @@ const UuidLikeStrSubClient_1 = require("./UuidLikeStrSubClient");
 const Total_1 = require("./Total");
 const OneOfUserSubTypes_1 = require("./OneOfUserSubTypes");
 exports.Transaction = core.serialization.object({
+    id: core.serialization.string().optional(),
     transactionGroupId: UuidLikeStrTransactionGroup_1.UuidLikeStrTransactionGroup.optional(),
     subClientId: UuidLikeStrSubClient_1.UuidLikeStrSubClient.optional(),
     transactionTotal: Total_1.Total.optional(),

--- a/ts/src/serialization/types/Wallet.d.ts
+++ b/ts/src/serialization/types/Wallet.d.ts
@@ -9,7 +9,7 @@ import { BlockChainEnum } from "./BlockChainEnum";
 export declare const Wallet: core.serialization.ObjectSchema<serializers.Wallet.Raw, PTI.Wallet>;
 export declare namespace Wallet {
     interface Raw {
-        walletId?: string | null;
+        id?: string | null;
         label?: string | null;
         currency?: CurrencyEnum.Raw | null;
         network?: BlockChainEnum.Raw | null;

--- a/ts/src/serialization/types/Wallet.js
+++ b/ts/src/serialization/types/Wallet.js
@@ -31,7 +31,7 @@ const core = __importStar(require("../../core"));
 const CurrencyEnum_1 = require("./CurrencyEnum");
 const BlockChainEnum_1 = require("./BlockChainEnum");
 exports.Wallet = core.serialization.object({
-    walletId: core.serialization.string().optional(),
+    id: core.serialization.string().optional(),
     label: core.serialization.string().optional(),
     currency: CurrencyEnum_1.CurrencyEnum.optional(),
     network: BlockChainEnum_1.BlockChainEnum.optional(),


### PR DESCRIPTION
Makes the object ids exposed "id" for create calls instead of requestId/walletId/feeRecipientId to be consistent