### PR TITLE
Add a github action to auto-publish the TypeScript SDK.

### DIFF
--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -1,4 +1,4 @@
-name: Release SDK's
+name: Release Java SDK
 
 on:
   workflow_dispatch:
@@ -16,8 +16,8 @@ env:
   GIT_KEY: ${{ secrets.CI_TOKEN }}
 
 jobs:
-  build:
-    name: Build & Release
+  release-java:
+    name: Build & release Java SDK
     runs-on: ubuntu-latest
 
     steps:
@@ -32,8 +32,9 @@ jobs:
           distribution: corretto
           java-version: 17
 
-      - name: Build and push Java
+      - name: Build and publish
         run: |
           cd java
           echo "version=${{ inputs.version }}" > gradle.properties
           ./gradlew publish
+

--- a/.github/workflows/release-ts.yml
+++ b/.github/workflows/release-ts.yml
@@ -1,0 +1,71 @@
+name: Release TypeScript SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_branch:
+        description: 'Tag/Branch to release'
+        type: string
+        required: true
+      version:
+        description: 'version to release'
+        type: string
+        required: true
+
+env:
+  GIT_KEY: ${{ secrets.CI_TOKEN }}
+
+jobs:
+  release-typescript:
+    name: Release TypeScript SDK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.tag_branch }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          echo -e "Checking for required packages...\n"
+          if ! command -v jq &>/dev/null; then
+            echo "JQ is not installed on the host. Installing now..."
+            sudo apt -qq update
+            sudo apt install jq -y
+          else
+            echo "JQ is already installed."
+          fi
+
+      - name: Set package version
+        working-directory: ts
+        run: |
+          jq --arg ver "${{ inputs.version }}" '.version = $ver' package.json > tmp.json && mv tmp.json package.json
+
+      - name: Commit and push updated package.json
+        working-directory: ts
+        run: |
+          git config --global user.email "github_actions@provenancetech.io"
+          git config --global user.name "Github Action"
+          git add package.json
+          if ! git diff --cached --quiet; then
+            git commit -m "Bump TypeScript SDK version to ${{ inputs.version }}"
+            git push --force origin ${{ inputs.tag_branch }}
+          else
+            echo "No changes to commit."
+          fi
+
+      - name: Install dependencies and publish
+        working-directory: ts
+        run: |
+          yarn install
+          yarn publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ env.GIT_KEY }}

--- a/ts/README.md
+++ b/ts/README.md
@@ -10,8 +10,8 @@ Building the API client library requires:
 ## Installation
 
 ### Published Package
-If you are not logged in to GitHub npm repository, 
-make sure to use a token which has the "read:write:delete repository" rights.
+If you're not already logged in to the GitHub npm registry, you'll be prompted for your GitHub 
+username and a password — which is actually a personal access token with `read:write:delete repository` scopes.
 ``` shell
 npm login --registry=https://npm.pkg.github.com
 ```
@@ -19,10 +19,12 @@ To publish the generated package to the GitHub npm registry, use the following c
 ``` shell
 yarn publish --access public
 ```
+This command will prompt you to enter the new SDK version number, so there's no need to update package.json manually beforehand.
 
 
 ### Locally
-To use the TypeScript SDK locally using Yarn or Npm, the simplest method is to create a link from this current repository and use this link in your projects.
+To use the TypeScript SDK locally using Yarn or Npm, the simplest method is to create a 
+link from this current repository and use this link in your projects.
 
 First, open a terminal in this directory `pti-platform-sdks/ts` and create a link using
 ```shell


### PR DESCRIPTION
- Update the readme for clearer manual steps.
- Add a github action to auto-publish the TS SDK.